### PR TITLE
Apply cap to prevent "Cannot query rows larger than 100MB" error

### DIFF
--- a/conf/tables.conf
+++ b/conf/tables.conf
@@ -48,7 +48,7 @@ readonly SELECT_PREFIXES="*"
 # Exporting.
 readonly EXPORT_DIR="${toplevel}/exported_tables"
 readonly EXPORT_FORMAT="Parquet"
-readonly PROBE_SRC_PORT_LIMIT="28096"
+readonly PROBE_SRC_PORT_LIMIT="28096" # diamond-miner's DEFAULT_PROBE_SRC_PORT + 4096
 readonly RESULTS_TABLE_EXPORT=$(cat <<EOF
   SELECT * REPLACE (
     CAST(capture_timestamp AS Int64) * 1000000 AS capture_timestamp,


### PR DESCRIPTION
The cap to flowid (probe_src_port)  reduces export time while ensuring relevant data is retained during table exports. Tested on the server for pipeline integrity and on BigQuery to verify the number of lines and absence of flowids > 28095.