### PR TITLE
Change floats to integers

### DIFF
--- a/db/iris_to_mlab.sql
+++ b/db/iris_to_mlab.sql
@@ -183,31 +183,31 @@ SELECT
         STRUCT(
             'cycle-start' AS Type,
             'default' AS list_name,
-            CAST(NULL AS FLOAT64) AS ID,
+            CAST(NULL AS INT64) AS ID,
             '%s' AS Hostname,
-            CAST(UNIX_SECONDS(MIN(last_timestamp)) AS FLOAT64) AS start_time
+            UNIX_SECONDS(MIN(last_timestamp)) AS start_time
         ) AS CycleStart,
         STRUCT(
             'tracelb' AS type,
             '%s' AS version,
-            CAST(NULL AS FLOAT64) AS userid,
+            CAST(NULL AS INT64) AS userid,
             '%s' AS method,
             probe_src_addr AS src,
             probe_dst_addr AS dst,
             make_timestamp(MIN(first_timestamp)) AS start,
-            CAST(NULL AS FLOAT64) AS probe_size,  -- Not stored in Iris
-            CAST('%s' AS FLOAT64) AS firsthop,
-            1.0 AS attempts,  -- Our current tools always send a single probe.
-            1.0 - CAST('%s' AS FLOAT64) AS confidence,
-            CAST(NULL AS FLOAT64) AS tos,  -- Not stored in Iris
-            CAST(NULL AS FLOAT64) AS gaplimit,  -- Not applicable
-            CAST(NULL AS FLOAT64) AS wait_timeout,  -- Not applicable
-            CAST(NULL AS FLOAT64) AS wait_probe,  -- Not applicable
-            CAST(NULL AS FLOAT64) AS probec,  -- TODO: Retrieve actual probe count from the measurement metadata.
-            CAST(NULL AS FLOAT64) AS probec_max,  -- Not applicable
-            CAST(COUNT(*) AS FLOAT64) AS nodec,
+            CAST(NULL AS INT64) AS probe_size,  -- Not stored in Iris
+            CAST('%s' AS INT64) AS firsthop,
+            1 AS attempts,  -- Our current tools always send a single probe.
+            100 - CAST(CAST('%s' AS FLOAT64)*100 AS INT64) AS confidence,
+            CAST(NULL AS INT64) AS tos,  -- Not stored in Iris
+            CAST(NULL AS INT64) AS gaplimit,  -- Not applicable
+            CAST(NULL AS INT64) AS wait_timeout,  -- Not applicable
+            CAST(NULL AS INT64) AS wait_probe,  -- Not applicable
+            CAST(NULL AS INT64) AS probec,  -- TODO: Retrieve actual probe count from the measurement metadata.
+            CAST(NULL AS INT64) AS probec_max,  -- Not applicable
+            COUNT(*)              AS nodec,
             (
-                SELECT CAST(COUNT(DISTINCT CONCAT(near_addr, '|', far_addr)) AS FLOAT64)
+                SELECT COUNT(DISTINCT CONCAT(near_addr, '|', far_addr))
                 FROM links
                 WHERE probe_protocol = lbn.probe_protocol
                   AND probe_src_addr = lbn.probe_src_addr
@@ -232,9 +232,9 @@ SELECT
         STRUCT(
             'cycle-stop' AS Type,
             'default' AS list_name,
-            CAST(NULL AS FLOAT64) AS ID,
+            CAST(NULL AS INT64) AS ID,
             '%s' AS Hostname,
-            CAST(UNIX_SECONDS(MAX(last_timestamp)) AS FLOAT64) AS stop_time
+            UNIX_SECONDS(MAX(last_timestamp)) AS stop_time
         ) AS CycleStop
     ) AS raw
 FROM links_by_node lbn

--- a/db/scamper1.json
+++ b/db/scamper1.json
@@ -28,9 +28,9 @@
       { "fields": [
           { "mode": "NULLABLE", "name": "Type", "type": "STRING" },
           { "mode": "NULLABLE", "name": "list_name", "type": "STRING" },
-          { "mode": "NULLABLE", "name": "ID", "type": "FLOAT" },
+          { "mode": "NULLABLE", "name": "ID", "type": "INTEGER" },
           { "mode": "NULLABLE", "name": "Hostname", "type": "STRING" },
-          { "mode": "NULLABLE", "name": "start_time", "type": "FLOAT" }
+          { "mode": "NULLABLE", "name": "start_time", "type": "INTEGER" }
         ],
         "mode": "NULLABLE",
         "name": "CycleStart",
@@ -39,7 +39,7 @@
       { "fields": [
           { "mode": "NULLABLE", "name": "type", "type": "STRING" },
           { "mode": "NULLABLE", "name": "version", "type": "STRING" },
-          { "mode": "NULLABLE", "name": "userid", "type": "FLOAT" },
+          { "mode": "NULLABLE", "name": "userid", "type": "INTEGER" },
           { "mode": "NULLABLE", "name": "method", "type": "STRING" },
           { "mode": "NULLABLE", "name": "src", "type": "STRING" },
           { "mode": "NULLABLE", "name": "dst", "type": "STRING" },
@@ -51,18 +51,18 @@
             "name": "start",
             "type": "RECORD"
           },
-          { "mode": "NULLABLE", "name": "probe_size", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "firsthop", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "attempts", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "confidence", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "tos", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "gaplimit", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "wait_timeout", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "wait_probe", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "probec", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "probec_max", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "nodec", "type": "FLOAT" },
-          { "mode": "NULLABLE", "name": "linkc", "type": "FLOAT" },
+          { "mode": "NULLABLE", "name": "probe_size", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "firsthop", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "attempts", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "confidence", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "tos", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "gaplimit", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "wait_timeout", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "wait_probe", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "probec", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "probec_max", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "nodec", "type": "INTEGER" },
+          { "mode": "NULLABLE", "name": "linkc", "type": "INTEGER" },
           { "fields": [
               { "mode": "NULLABLE", "name": "hop_id", "type": "STRING" },
               { "mode": "NULLABLE", "name": "addr", "type": "STRING" },
@@ -133,9 +133,9 @@
       { "fields": [
           { "mode": "NULLABLE", "name": "Type", "type": "STRING" },
           { "mode": "NULLABLE", "name": "list_name", "type": "STRING" },
-          { "mode": "NULLABLE", "name": "ID", "type": "FLOAT" },
+          { "mode": "NULLABLE", "name": "ID", "type": "INTEGER" },
           { "mode": "NULLABLE", "name": "Hostname", "type": "STRING" },
-          { "mode": "NULLABLE", "name": "stop_time", "type": "FLOAT" }
+          { "mode": "NULLABLE", "name": "stop_time", "type": "INTEGER" }
         ],
         "mode": "NULLABLE",
         "name": "CycleStop",


### PR DESCRIPTION
* Use INT64 instead of FLOAT64 for fields which are inherently integers.

* Testing & validation
- Tested on the server to ensure pipeline integrity.
- Checked that INT64 fields are represented as INTEGERS in BigQuery.