### PR TITLE
Separate datasets

### DIFF
--- a/conf/tables.conf
+++ b/conf/tables.conf
@@ -22,8 +22,8 @@ readonly MEAS_MD_ALL_JSON="${toplevel}/cache/meas_md_all.json"
 readonly MEAS_MD_SELECTED_TXT="${toplevel}/cache/meas_md_selected.txt"
 readonly MEAS_TAG="zeph-gcp-daily.json"
 readonly MEAS_STATE="finished"
-readonly MEAS_AFTER="2024-12-04"
-readonly MEAS_BEFORE="2024-12-06" # if not set, current date will be used
+readonly MEAS_AFTER="2024-01-04"
+readonly MEAS_BEFORE="2024-01-14" # if not set, current date will be used
 readonly NUM_AGENTS="10"
 readonly NUM_AGENTS_FINISHED="10"
 
@@ -85,8 +85,9 @@ EOF
 )
 # Uploading.
 readonly GCP_PROJECT_ID="mlab-edgenet"
-readonly BQ_DATASET="iris_test"
-readonly BQ_TABLE="elena1"
+readonly BQ_PUBLIC_DATASET="iris_test" # public dataset with tables in scamper1 format
+readonly BQ_PRIVATE_DATASET="iris_test_2" # private dataset to store temporary tables during conversion
+readonly BQ_TABLE="elena1" # table in scamper1 format
 readonly SCHEMA_RESULTS_JSON="${toplevel}/db/schema_results.json"
 readonly SCHEMA_SCAMPER1_JSON="${toplevel}/db/scamper1.json"
 readonly TABLE_CONVERSION_QUERY="${toplevel}/db/iris_to_mlab.sql"


### PR DESCRIPTION
* Separate the public dataset with tables in scamper1 format from the private dataset used for upload and conversion of temporary tables

* This commit also adds a function to verify the existence of datasets

* Testing & validation
- Tested on the server to ensure pipeline integrity
- Checked the correct behaviour of verify_dataset()
- Verified the creation of two separate datasets