### PR TITLE
Partition table in scamper1 format by measurement date

### DIFF
--- a/db/iris_to_mlab.sql
+++ b/db/iris_to_mlab.sql
@@ -172,7 +172,7 @@ SELECT
         CAST(NULL AS INT64) AS Priority,
         CAST(NULL AS STRING) AS GitCommit
     ) AS parser,
-    CURRENT_DATE() AS date,
+    DATE(MIN(first_timestamp)) AS date,
     STRUCT(
         STRUCT(
             GENERATE_UUID() AS UUID,
@@ -185,7 +185,7 @@ SELECT
             'default' AS list_name,
             CAST(NULL AS INT64) AS ID,
             '%s' AS Hostname,
-            UNIX_SECONDS(MIN(last_timestamp)) AS start_time
+            UNIX_SECONDS(MIN(first_timestamp)) AS start_time
         ) AS CycleStart,
         STRUCT(
             'tracelb' AS type,

--- a/tools/upload_tables.sh
+++ b/tools/upload_tables.sh
@@ -59,8 +59,8 @@ main() {
 		echo "${bq_dataset_table} already exists"
 	else
 		# create the $BQ_TABLE table with the schema file
-		echo bq mk --project_id "${GCP_PROJECT_ID}" --schema "${SCHEMA_SCAMPER1_JSON}" --clustering_fields "id" --table "${bq_dataset_table}"
-		"${TIME}" bq mk --project_id "${GCP_PROJECT_ID}" --schema "${SCHEMA_SCAMPER1_JSON}" --clustering_fields "id" --table "${bq_dataset_table}"
+		echo bq mk --project_id "${GCP_PROJECT_ID}" --schema "${SCHEMA_SCAMPER1_JSON}" --clustering_fields "id" --time_partitioning_field "date" --time_partitioning_type DAY --table "${bq_dataset_table}"
+		"${TIME}" bq mk --project_id "${GCP_PROJECT_ID}" --schema "${SCHEMA_SCAMPER1_JSON}" --clustering_fields "id" --time_partitioning_field "date" --time_partitioning_type DAY --table "${bq_dataset_table}"
 	fi
 
 	echo "tables to upload: ${TABLES_TO_UPLOAD[*]}"


### PR DESCRIPTION
* Use measurement date instead of current date as date field

* Partition by DAY using the measurement date field
  - Each partition corresponds to a specific day's measurement run.

* Correct start_time field

* Testing & validation
- Tested on the server to ensure pipeline integrity.
- Verified that the table is partitioned and contains multiple partitions