### PR TITLE
Use measurement_uuid as id field

### DIFF
--- a/tools/upload_tables.sh
+++ b/tools/upload_tables.sh
@@ -185,6 +185,7 @@ convert_and_insert_values() {
 	"${TIME}" bq query --project_id="${GCP_PROJECT_ID}" \
 		--use_legacy_sql=false \
 		--parameter="scamper1_table_name_param:STRING:${BQ_PUBLIC_DATASET}.${BQ_TABLE}" \
+		--parameter="measurement_uuid_param:STRING:${meas_uuid}" \
 		--parameter="table_name_param:STRING:${bq_tmp_table}" \
 		--parameter="measurement_agent_param:STRING:${bq_tmp_table#*__}" \
 		--parameter="tool_param:STRING:${tool}" \


### PR DESCRIPTION
* Update the pipeline to use measurement_uuid as the id field to simplify measurement queries for users

* Move the SHA256 value for duplicate prevention to raw.Metadata.UUID

* Add a filter for measurement_uuid in the WHERE NOT EXISTS clause to improve duplicate verification performance

* Testing & Validation
- Verified pipeline integrity on the server.
- Confirmed measurement_uuid is correctly inserted.
- Ensured rows are not inserted twice.