### PR TITLE
Group nodes and links by probe_dst_prefix

### DIFF
--- a/conf/tables.conf
+++ b/conf/tables.conf
@@ -23,7 +23,7 @@ readonly MEAS_MD_SELECTED_TXT="${toplevel}/cache/meas_md_selected.txt"
 readonly MEAS_TAG="zeph-gcp-daily.json"
 readonly MEAS_STATE="finished"
 readonly MEAS_AFTER="2024-01-04"
-readonly MEAS_BEFORE="2024-01-14" # if not set, current date will be used
+readonly MEAS_BEFORE="2024-12-31" # if not set, current date will be used
 readonly NUM_AGENTS="10"
 readonly NUM_AGENTS_FINISHED="10"
 
@@ -50,26 +50,20 @@ readonly EXPORT_DIR="${toplevel}/exported_tables"
 readonly EXPORT_FORMAT="Parquet"
 readonly PROBE_SRC_PORT_LIMIT="28096" # diamond-miner's DEFAULT_PROBE_SRC_PORT + 4096
 readonly CLEANED_RESULTS_TABLE_EXPORT=$(cat <<EOF
-  SELECT * REPLACE (
+  SELECT
     CAST(capture_timestamp AS Int64) * 1000000 AS capture_timestamp,
-    IPv6NumToString(probe_src_addr) AS probe_src_addr,
-    IPv6NumToString(probe_dst_addr) AS probe_dst_addr,
-    IPv6NumToString(reply_src_addr) AS reply_src_addr
-  )
-  EXCEPT (
-    reply_protocol,
-    reply_size,
-    reply_mpls_labels,
-    round,
-    probe_dst_prefix,
-    reply_src_prefix,
-    private_probe_dst_prefix,
-    private_reply_src_addr,
-    destination_host_reply,
-    destination_prefix_reply,
-    valid_probe_protocol,
-    time_exceeded_reply
-  )
+    probe_protocol 			       AS probe_protocol,
+    IPv6NumToString(probe_src_addr)   	       AS probe_src_addr,
+    IPv6NumToString(probe_dst_addr)            AS probe_dst_addr,
+    probe_src_port 			       AS probe_src_port,
+    probe_ttl 				       AS probe_ttl,
+    quoted_ttl 				       AS quoted_ttl,
+    IPv6NumToString(reply_src_addr)            AS reply_src_addr,
+    reply_icmp_type 			       AS reply_icmp_type,
+    reply_icmp_code 			       AS reply_icmp_code,
+    reply_ttl 				       AS reply_ttl,
+    rtt 				       AS rtt,
+    IPv6NumToString(probe_dst_prefix)          AS probe_dst_prefix
   FROM \${DATABASE_NAME}.\${table}
   WHERE probe_src_port < $PROBE_SRC_PORT_LIMIT AND
   	probe_dst_prefix in (
@@ -84,10 +78,10 @@ readonly CLEANED_RESULTS_TABLE_EXPORT=$(cat <<EOF
 EOF
 )
 # Uploading.
-readonly GCP_PROJECT_ID=""
-readonly BQ_PUBLIC_DATASET="" # public dataset with tables in scamper1 format
-readonly BQ_PRIVATE_DATASET="" # private dataset to store temporary tables during conversion
-readonly BQ_TABLE="" # table in scamper1 format
+readonly GCP_PROJECT_ID="mlab-edgenet"
+readonly BQ_PUBLIC_DATASET="sorbonne" # public dataset with tables in scamper1 format
+readonly BQ_PRIVATE_DATASET="sorbonne_private" # private dataset to store temporary tables during conversion
+readonly BQ_TABLE="iris_iprs1" # table in scamper1 format
 readonly SCHEMA_RESULTS_JSON="${toplevel}/db/schema_results.json"
 readonly SCHEMA_SCAMPER1_JSON="${toplevel}/db/scamper1.json"
 readonly TABLE_CONVERSION_QUERY="${toplevel}/db/iris_to_mlab.sql"
@@ -98,14 +92,15 @@ readonly SCHEMA_RESULTS=$(cat <<EOF
   { "name": "probe_src_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "probe_dst_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "probe_src_port", "type": "INTEGER", "mode": "REQUIRED" },
-  { "name": "probe_dst_port", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "probe_ttl", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "quoted_ttl", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_src_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "reply_icmp_type", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_icmp_code", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_ttl", "type": "INTEGER", "mode": "REQUIRED" },
-  { "name": "rtt", "type": "INTEGER", "mode": "REQUIRED" }]
+  { "name": "rtt", "type": "INTEGER", "mode": "REQUIRED" },
+  { "name": "probe_dst_prefix", "type": "STRING", "mode": "REQUIRED" }
+]
 EOF
 )
 

--- a/db/schema_results.json
+++ b/db/schema_results.json
@@ -4,11 +4,12 @@
   { "name": "probe_src_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "probe_dst_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "probe_src_port", "type": "INTEGER", "mode": "REQUIRED" },
-  { "name": "probe_dst_port", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "probe_ttl", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "quoted_ttl", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_src_addr", "type": "STRING", "mode": "REQUIRED" },
   { "name": "reply_icmp_type", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_icmp_code", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "reply_ttl", "type": "INTEGER", "mode": "REQUIRED" },
-  { "name": "rtt", "type": "INTEGER", "mode": "REQUIRED" }]
+  { "name": "rtt", "type": "INTEGER", "mode": "REQUIRED" },
+  { "name": "probe_dst_prefix", "type": "STRING", "mode": "REQUIRED" }
+]


### PR DESCRIPTION
* Since in iris, a route trace corresponds to a destination prefix rather than a destination address, this commit updates the logic to group nodes and links by probe_dst_prefix instead of probe_dst_addr.

* Additionally:
 - probe_dst_prefix is now included as a field when exporting tables.
 - probe_dst_prefix is used to prevent duplicate row insertion, replacing the previous use of a SHA-256 hash.

* Testing & Validation
 - Verified pipeline integrity on the server.
 - Verified correctness of grouping.