### PR TITLE
Use external IP address for `src_addr`

### DIFF
--- a/conf/instances.conf
+++ b/conf/instances.conf
@@ -1,0 +1,11 @@
+NAME                     ZONE                  MACHINE_TYPE  PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP     STATUS
+iris-asia-east1          asia-east1-b          e2-highcpu-2               10.0.0.2     35.206.254.77   RUNNING
+iris-us-east1            us-east1-b            e2-highcpu-2               10.0.8.2     35.211.80.249   RUNNING
+iris-asia-northeast1     asia-northeast1-b     e2-highcpu-2               10.0.1.2     35.213.48.22    RUNNING
+iris-asia-southeast1     asia-southeast1-b     e2-highcpu-2               10.0.3.2     34.1.135.124    RUNNING
+iris-southamerica-east1  southamerica-east1-b  e2-highcpu-2               10.0.7.2     35.215.225.180  RUNNING
+iris-asia-south1         asia-south1-b         e2-highcpu-2               10.0.2.2     35.207.194.190  RUNNING
+iris-europe-north1       europe-north1-b       e2-highcpu-2               10.0.4.2     35.217.62.64    RUNNING
+iris-europe-west6        europe-west6-b        e2-highcpu-2               10.0.5.2     35.216.144.191  RUNNING
+iris-us-west4            us-west4-b            e2-highcpu-2               10.0.9.2     35.219.146.145  RUNNING
+iris-me-central1         me-central1-b         e2-highcpu-2               10.0.6.2     34.1.45.88      RUNNING

--- a/conf/tables.conf
+++ b/conf/tables.conf
@@ -79,6 +79,7 @@ EOF
 )
 # Uploading.
 readonly GCP_PROJECT_ID="mlab-edgenet"
+readonly GCP_INSTANCES="${toplevel}/conf/instances.conf"
 readonly BQ_PUBLIC_DATASET="iris_test" # public dataset with tables in scamper1 format
 readonly BQ_PRIVATE_DATASET="iris_test_1" # private dataset to store temporary tables during conversion
 readonly BQ_PUBLIC_TABLE="iris_iprs1" # table in scamper1 format

--- a/db/iris_to_mlab.sql
+++ b/db/iris_to_mlab.sql
@@ -18,6 +18,8 @@ DECLARE
 DECLARE
   agent_uuid STRING DEFAULT @agent_uuid_param;
 DECLARE
+  src_addr STRING DEFAULT @src_addr_param;
+DECLARE
   min_ttl STRING DEFAULT @min_ttl_param;
 DECLARE
   failure_probability STRING DEFAULT @failure_probability_param;
@@ -255,7 +257,7 @@ SELECT
      CAST(NULL AS STRING) AS version,
      CAST(NULL AS INT64) AS userid,
      'icmp-echo' AS method,
-     probe_src_addr AS src,
+     '%s' AS src,
      probe_dst_prefix AS dst,
      make_timestamp(MIN(first_timestamp)) AS start,
      CAST(NULL AS INT64) AS probe_size,  -- Not stored in Iris
@@ -306,8 +308,8 @@ GROUP BY
  probe_src_addr,
  probe_dst_prefix
 """, scamper1_table, iris_table, scamper1_table, measurement_uuid,
-hostname, measurement_uuid, start_time, agent_uuid, hostname, min_ttl,
-failure_probability, hostname);
+hostname, measurement_uuid, start_time, agent_uuid, hostname, src_addr,
+min_ttl, failure_probability, hostname);
 
 EXECUTE IMMEDIATE
   convert_iris_to_scamper1;


### PR DESCRIPTION
* Introduce `src_addr` as a new parameter in the `iris_to_mlab.sql` query to store the external IP address.
* Update `iris_to_mlab.sql` to replace the internal `probe_src_addr` with the external `src_addr`.
* Modifiy `upload_tables.sh` to retrieve `src_addr` from `GCP_INSTANCES` if available.
* Implement error handling for a missing `GCP_INSTANCES` file.
* Ensure `src_addr` extraction from measurement metadata when `GCP_INSTANCES` is not set.
* Testing & validation
   - Verified pipeline integrity through local testing.
   - Validated Traceb.src  values against expected results.