### PR TITLE
Is published

### DIFF
--- a/conf/settings.conf
+++ b/conf/settings.conf
@@ -33,8 +33,8 @@ readonly MEAS_TAG="zeph-gcp-daily.json"
 # Variables related to processing measurements.
 #
 #readonly MEAS_UUID_PROCESS_TXT="${toplevel}/cache/meas_uuid_process.txt"
-#readonly MEAS_AFTER="2024-01-04"
-#readonly MEAS_BEFORE="2025-01-31" # if not set, current date will be used
+#readonly MEAS_AFTER="2025-01-04"
+#readonly MEAS_BEFORE="2025-01-10" # if not set, current date will be used
 
 #
 # Variables related to uploading metadata.
@@ -113,6 +113,7 @@ readonly GCP_PROJECT_ID="mlab-edgenet"
 readonly BQ_PUBLIC_DATASET="iris_test" # public dataset with tables in scamper1 format
 readonly BQ_PRIVATE_DATASET="iris_test_1" # private dataset to store temporary tables during conversion
 readonly BQ_PUBLIC_TABLE="iris_iprs1" # table in scamper1 format
+readonly BQ_METADATA_TABLE="metadata" # metadata table
 readonly SCHEMA_RESULTS_JSON="${toplevel}/db/schema_results.json"
 readonly SCHEMA_SCAMPER1_JSON="${toplevel}/db/schema_scamper1.json"
 readonly TABLE_CONVERSION_QUERY="${toplevel}/db/iris_to_mlab.sql"
@@ -132,6 +133,12 @@ readonly SCHEMA_RESULTS=$(cat <<EOF
   { "name": "rtt", "type": "INTEGER", "mode": "REQUIRED" },
   { "name": "probe_dst_prefix", "type": "STRING", "mode": "REQUIRED" }
 ]
+EOF
+)
+readonly UPDATE_WHERE_PUBLISHED=$(cat <<EOF
+  UPDATE \`${BQ_PUBLIC_DATASET}.${BQ_METADATA_TABLE}\`
+  SET is_published = True
+  WHERE id = '\${meas_uuid}'
 EOF
 )
 

--- a/conf/settings.conf
+++ b/conf/settings.conf
@@ -33,8 +33,8 @@ readonly MEAS_TAG="zeph-gcp-daily.json"
 # Variables related to processing measurements.
 #
 #readonly MEAS_UUID_PROCESS_TXT="${toplevel}/cache/meas_uuid_process.txt"
-#readonly MEAS_AFTER="2025-01-04"
-#readonly MEAS_BEFORE="2025-01-10" # if not set, current date will be used
+#readonly MEAS_AFTER="2024-01-04"
+#readonly MEAS_BEFORE="2025-01-31" # if not set, current date will be used
 
 #
 # Variables related to uploading metadata.
@@ -46,12 +46,11 @@ readonly SCHEMA_TMP_METADATA_JSON="${toplevel}/db/schema_tmp_metadata.json"
 readonly SNAPSHOT_LABELS="[]" # use "[]" in case of no labels
 readonly IRIS_VERSION=""
 readonly DIAMOND_MINER_VERSION=""
-readonly ZEPH_VERSION="" 
-readonly CARACAL_VERSION="" 
+readonly ZEPH_VERSION=""
+readonly CARACAL_VERSION=""
 readonly PARSER_VERSION=""
 readonly IPV4=True
 readonly IPV6=False
-readonly WHERE_PUBLISHED="[]" 
 
 #
 # Variables related to cleaning data.

--- a/conf/settings.conf
+++ b/conf/settings.conf
@@ -134,7 +134,7 @@ readonly SCHEMA_RESULTS=$(cat <<EOF
 ]
 EOF
 )
-readonly UPDATE_WHERE_PUBLISHED=$(cat <<EOF
+readonly UPDATE_IS_PUBLISHED=$(cat <<EOF
   UPDATE \`${BQ_PUBLIC_DATASET}.${BQ_METADATA_TABLE}\`
   SET is_published = True
   WHERE id = '\${meas_uuid}'

--- a/db/schema_metadata.json
+++ b/db/schema_metadata.json
@@ -18,6 +18,6 @@
   "type": "RECORD"
   },
   { "name": "IPv4", "type": "BOOLEAN", "mode": "NULLABLE" },
-  { "name": "IPv6", "type": "BOOLEAN", "mode": "NULLABLE"},
-  { "name": "where_published", "type": "STRING", "mode": "REPEATED" }
+  { "name": "IPv6", "type": "BOOLEAN", "mode": "NULLABLE" },
+  { "name": "is_published", "type": "BOOLEAN", "mode": "NULLABLE" }
 ]

--- a/tools/upload_data.sh
+++ b/tools/upload_data.sh
@@ -26,7 +26,6 @@ EOF
 
 main() {
 	local bq_metadata_table
-	local resources
 	local resource
 	local bq_public_table
 	local meas_md_tmpfile
@@ -43,9 +42,8 @@ main() {
 
 	# check if datasets and metadata table exist
 	bq_metadata_table="${BQ_PUBLIC_DATASET}.${BQ_METADATA_TABLE:?unset BQ_METADATA_TABLE}"
-	resources=("${BQ_PUBLIC_DATASET}" "${BQ_PRIVATE_DATASET}" "${bq_metadata_table}")
-	echo "checking ${resources[*]}"
-	for resource  in "${resources[@]}"; do
+	echo "checking datasets and tables"
+	for resource in "${BQ_PUBLIC_DATASET}" "${BQ_PRIVATE_DATASET}" "${bq_metadata_table}"; do
 		if ! check_dataset_or_table "${resource}"; then
 			echo "error: ${resource} does not exist"
 			exit 1
@@ -83,7 +81,7 @@ main() {
 			upload_data "${meas_uuid}" "${meas_md_tmpfile}" "${table_prefix}"
 			echo
 		# finally, update where_published field in BQ_METADATA_TABLE
-		query="${UPDATE_WHERE_PUBLISHED//\$\{meas_uuid\}/$meas_uuid}"
+		query="${UPDATE_IS_PUBLISHED//\$\{meas_uuid\}/$meas_uuid}"
 		echo "bq query --use_legacy_sql=false --project_id=${GCP_PROJECT_ID} ${query}"
 		bq query --use_legacy_sql=false --project_id="${GCP_PROJECT_ID}" "${query}"
 		done

--- a/tools/upload_metadata.sh
+++ b/tools/upload_metadata.sh
@@ -173,7 +173,7 @@ SELECT
     ) AS sw_versions,
     ${IPV4} AS IPv4,
     ${IPV6} AS IPv6,
-    False AS where_published
+    False AS is_published
 FROM \`${bq_tmp_table}\` tmp_metadata
 WHERE NOT EXISTS (
     SELECT 1


### PR DESCRIPTION
 Use and update is_published Field in Metadata Table

-  Changes
        - Replace the where_published array field in the metadata table with the boolean is_published field for simplicity.
        - Set is_published to true after successfully uploading and converting measurements.
        - Introduce sanity checks to ensure data consistency.

- Testing & Validation
        - Verified pipeline integrity through local testing.
        - Validated where_published values against expected results.