### PR TITLE
cherry-pick: Restore changes related to external IP address usage for `src_addr`

### DIFF
--- a/conf/settings.conf
+++ b/conf/settings.conf
@@ -109,6 +109,7 @@ readonly TABLES_TO_CLEAN=(results__)
 readonly TABLES_TO_EXPORT=(results__)
 readonly TABLES_TO_UPLOAD=(results__)
 readonly GCP_PROJECT_ID="mlab-edgenet"
+readonly GCP_INSTANCES="${toplevel}/conf/instances.conf"
 readonly BQ_PUBLIC_DATASET="iris_test" # public dataset with tables in scamper1 format
 readonly BQ_PRIVATE_DATASET="iris_test_1" # private dataset to store temporary tables during conversion
 readonly BQ_PUBLIC_TABLE="iris_iprs1" # table in scamper1 format


### PR DESCRIPTION
This commit cherry-picks commit 7158c2f1e414a5b2760f1c441bb4b8e78f689ecc, which was mistakenly dropped in earlier commits.
