### PR TITLE
Refactor script to handle a single measurement UUID

### DIFF
--- a/conf/settings.conf
+++ b/conf/settings.conf
@@ -40,9 +40,7 @@ readonly MEAS_TAG="zeph-gcp-daily.json"
 # Variables related to uploading metadata.
 #
 readonly MEAS_STATES=("canceled" "finished" "agent_failure")
-readonly BQ_TMP_TABLE="tmp_meta"
 readonly SCHEMA_METADATA_JSON="${toplevel}/db/schema_metadata.json"
-readonly SCHEMA_TMP_METADATA_JSON="${toplevel}/db/schema_tmp_metadata.json"
 readonly SNAPSHOT_LABELS="[]" # use "[]" in case of no labels
 readonly IRIS_VERSION=""
 readonly DIAMOND_MINER_VERSION=""

--- a/db/README.txt
+++ b/db/README.txt
@@ -1,10 +1,2 @@
 This directory contains schema and query files used by various tools
 to interact with the databases.
-
-`schema_tmp_metadata` defines the structure of the temporary metadata
-table, which serves as a staging area for converting schema formats.
-This table stores measurement metadata, retrievable via `irisctl`,
-while additional metadata is sourced from the configuration file
-and incorporated during the final insertion.  Using this staging
-table enhances efficiency by minimizing the need for multiple
-BigQuery calls, thereby streamlining the entire process.

--- a/db/schema_tmp_metadata.json
+++ b/db/schema_tmp_metadata.json
@@ -1,9 +1,0 @@
-[
-  { "name": "id", "type": "STRING", "mode": "REQUIRED" },
-  { "name": "start_time", "type": "TIMESTAMP", "mode": "REQUIRED" },
-  { "name": "end_time", "type": "TIMESTAMP", "mode": "REQUIRED" },
-  { "name": "snapshot_status", "type": "STRING", "mode": "REQUIRED" },
-  { "name": "num_agents", "type": "INTEGER", "mode": "REQUIRED" },
-  { "name": "num_succesful_agents", "type": "INTEGER", "mode": "REQUIRED" }
-]
-


### PR DESCRIPTION
### Changes
- Modify script to accept a single `meas_uuid` as an argument instead of processing multiple measurements.
- Remove unnecessary dataset-wide metadata fetching and selection logic.
- Eliminate the temporary BigQuery table and insert metadata directly into `BQ_METADATA_TABLE`.
- Add `check_uuid_in_metadata` to prevent duplicate inserts.

### Testing & Validation
- Verified pipeline integrity through local testing.
- Validated expected vs. actual outcomes of metadata uploads to BigQuery.